### PR TITLE
feat: strengthen OpenClaw SEO page links

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -791,6 +791,56 @@ button:disabled {
   gap: 12px;
 }
 
+.seo-related-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 18px;
+}
+
+.seo-related-card {
+  display: flex;
+  min-height: 154px;
+  flex-direction: column;
+  gap: 10px;
+  padding: 18px;
+  border: 1px solid rgba(255, 107, 0, 0.14);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.68);
+  color: inherit;
+  text-decoration: none;
+  transition: border-color 180ms ease, box-shadow 180ms ease, transform 180ms ease;
+}
+
+.seo-related-card:hover {
+  border-color: rgba(255, 107, 0, 0.28);
+  box-shadow: 0 18px 46px -38px rgba(255, 107, 0, 0.42);
+  transform: translate3d(0, -1px, 0);
+}
+
+.seo-related-card__title {
+  color: var(--text);
+  font-size: 16px;
+  font-weight: 900;
+  line-height: 1.45;
+}
+
+.seo-related-card__desc {
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.7;
+}
+
+.seo-related-card__action {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: auto;
+  color: var(--primary-strong);
+  font-size: 14px;
+  font-weight: 900;
+}
+
 .seo-resource {
   justify-content: space-between;
   min-height: 54px;
@@ -3938,6 +3988,58 @@ button[data-loading="true"] .btn__loading {
   gap: 12px;
   padding-bottom: 10px;
   border-bottom: 1px solid rgba(255, 107, 0, 0.1);
+}
+
+.pc-retention-seo-link {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 64px;
+  padding: 12px 14px;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 107, 0, 0.18);
+  background: rgba(255, 250, 245, 0.9);
+  color: inherit;
+  text-decoration: none;
+  box-shadow: 0 12px 36px -34px rgba(255, 107, 0, 0.3),
+    0 0 0 1px rgba(255, 255, 255, 0.76) inset;
+  transition: border-color 180ms ease-out, box-shadow 180ms ease-out, transform 180ms ease-out;
+}
+
+.pc-retention-seo-link:hover {
+  border-color: rgba(255, 107, 0, 0.32);
+  box-shadow: 0 18px 46px -38px rgba(255, 107, 0, 0.42),
+    0 0 0 1px rgba(255, 255, 255, 0.84) inset;
+  transform: translate3d(0, -1px, 0);
+}
+
+.pc-retention-seo-link__content {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.pc-retention-seo-link__eyebrow {
+  color: rgba(124, 94, 77, 0.78);
+  font-size: 12px;
+  font-weight: 900;
+  line-height: 1.2;
+}
+
+.pc-retention-seo-link__title {
+  color: var(--text);
+  font-size: 15px;
+  font-weight: 950;
+  line-height: 1.35;
+}
+
+.pc-retention-seo-link .icon {
+  flex: 0 0 auto;
+  width: 18px;
+  height: 18px;
+  color: var(--primary);
 }
 
 .pc-retention-board__tabs {
@@ -7773,7 +7875,8 @@ body.is-detail::after {
     width: 100%;
   }
   .seo-grid,
-  .seo-link-grid {
+  .seo-link-grid,
+  .seo-related-grid {
     grid-template-columns: 1fr;
   }
   .seo-lead {

--- a/app/seo/openclaw-wsl2-codex-tool-calls/page.tsx
+++ b/app/seo/openclaw-wsl2-codex-tool-calls/page.tsx
@@ -69,6 +69,29 @@ const howToSteps = [
   "把错误归类为 missing tool、permission denied、command failure、timeout 或 resource exhaustion。",
 ] as const;
 
+const relatedPracticeLinks = [
+  {
+    href: "/practice/193",
+    title: "Codex Skills 初体验，第一个技能创建和使用",
+    description: "从 Codex 使用 Skill 的真实流程切入，适合作为理解 Agent Skills directory 的下一步。",
+  },
+  {
+    href: "/practice/194",
+    title: "OpenClaw 打工人高效工作流",
+    description: "把 OpenClaw 放进日常任务流，帮助判断 tool calls 问题是否来自会话编排或工具暴露。",
+  },
+  {
+    href: "/practice/168",
+    title: "Claude Code Skills：从手写到工具化",
+    description: "对照 AGENTS.md、SKILL.md 与可复用工作流，理解为什么单纯堆 prompt 不够稳定。",
+  },
+  {
+    href: "/practice/125",
+    title: "agent-browser vs browser-use 深度测评",
+    description: "浏览器自动化工具的高点击实践页，可承接 tool call 成功后如何选择具体 Skill。",
+  },
+] as const;
+
 function toJsonLd(value: Record<string, unknown>): string {
   return JSON.stringify(value).replace(/</g, "\\u003c");
 }
@@ -290,6 +313,26 @@ export default function Page() {
                 <li key={step}>{step}</li>
               ))}
             </ol>
+          </section>
+
+          <section className="seo-section" aria-labelledby="related-practice-title">
+            <h2 id="related-practice-title">相关实践入口</h2>
+            <p>
+              排查完成后，下一步是把可用 tool calls 接到具体任务。下面这些实践页能帮助你从 Codex、
+              OpenClaw 和 Agent Skills 的概念，落到真实工作流。
+            </p>
+            <div className="seo-related-grid">
+              {relatedPracticeLinks.map((item) => (
+                <Link className="seo-related-card" href={item.href} key={item.href}>
+                  <span className="seo-related-card__title">{item.title}</span>
+                  <span className="seo-related-card__desc">{item.description}</span>
+                  <span className="seo-related-card__action">
+                    查看实践
+                    <ArrowRight className="icon" aria-hidden="true" />
+                  </span>
+                </Link>
+              ))}
+            </div>
           </section>
 
           <section className="seo-section" aria-labelledby="evidence-title">

--- a/components/home/HomeRetentionBanner.tsx
+++ b/components/home/HomeRetentionBanner.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { memo, useEffect, useMemo, useRef, useState } from "react";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { ArrowRight, ChevronLeft, ChevronRight } from "lucide-react";
 import { formatNumberWithCommas } from "@/lib/format";
 import type { BoardEntry, BoardTabKey, HomeMetrics } from "@/lib/types";
 import { trackEvent } from "@/lib/analytics";
@@ -69,6 +69,8 @@ const TAB_CONFIG: Array<{ key: BoardTabKey; label: string; analyticsTab: "weekly
   { key: "weekly", label: "每周精选", analyticsTab: "weekly_featured" },
   { key: "hot", label: "热门榜单", analyticsTab: "hot" },
 ];
+
+const SEO_GUIDE_LINK = "/seo/openclaw-wsl2-codex-tool-calls";
 
 type KpiMetricKey = (typeof KPI_CONFIG)[number]["key"];
 type KpiMetricMap = Record<KpiMetricKey, number | null>;
@@ -458,6 +460,13 @@ function HomeRetentionBanner({
     });
   };
 
+  const onSeoGuideClick = () => {
+    trackEvent("home_seo_guide_click", {
+      guide: "openclaw_wsl2_codex_tool_calls",
+      placement: "home_retention_board",
+    });
+  };
+
   const activeSlide = activePages[activePageIndex] || [];
 
   return (
@@ -580,6 +589,14 @@ function HomeRetentionBanner({
                   </button>
                 </div>
               </div>
+
+              <a className="pc-retention-seo-link" href={SEO_GUIDE_LINK} onClick={onSeoGuideClick}>
+                <span className="pc-retention-seo-link__content">
+                  <span className="pc-retention-seo-link__eyebrow">OpenClaw / Codex 专题</span>
+                  <span className="pc-retention-seo-link__title">WSL2 tool calls 排查指南</span>
+                </span>
+                <ArrowRight className="icon" aria-hidden="true" />
+              </a>
 
               <div className="pc-retention-board__viewport">
                 {isActiveTabLoading && activeSlide.length === 0 ? (

--- a/manage/seo-openclaw-optimization-plan-2026-06-25.md
+++ b/manage/seo-openclaw-optimization-plan-2026-06-25.md
@@ -1,0 +1,46 @@
+# OpenClaw SEO Optimization Plan - 2026-06-25
+
+目标页：`/seo/openclaw-wsl2-codex-tool-calls`
+
+基线：GSC 7/28 天均 `0` 展现；抓取链路正常。
+
+## 排期
+
+| 优先级 | 动作 | 排期 | 验收口径 | 状态 |
+| --- | --- | --- | --- | --- |
+| P0 | 主题集群内链 | `2026-06-25` | 目标页新增相关 practice 内链；锚文本覆盖 Codex/OpenClaw/Agent Skills/tool calls | 已实施 |
+| P0 | 首页可见入口 | `2026-06-25` | 首页 PC 首屏更新看板新增可见专题入口；保留首页 title 不变 | 已实施 |
+| P1 | 长尾段落扩写 | `2026-06-26` | 新增 2-3 个问题型 H2，覆盖 `Codex MCP tools not showing`、`Windows WSL2 路径混用`、`OpenClaw dynamic tools vs MCP tools` | 待做 |
+| P1 | GSC 手动提交 | `2026-06-26` | URL inspection 请求索引；重新提交 sitemap；记录控制台结果 | 待做 |
+| P1 | 7/14/28 天复测 | `2026-07-02` / `2026-07-09` / `2026-07-23` | 记录目标页 page filter clicks/impressions/query rows；若 14 天仍 0 展现，继续加内链与内容 | 待做 |
+
+## 本次实施范围
+
+1. 首页可见入口：
+   - 文件：`components/home/HomeRetentionBanner.tsx`
+   - 位置：PC 首屏更新看板
+   - 链接：`/seo/openclaw-wsl2-codex-tool-calls`
+   - 埋点：`home_seo_guide_click`
+
+2. 主题集群内链：
+   - 文件：`app/seo/openclaw-wsl2-codex-tool-calls/page.tsx`
+   - 新增“相关实践入口”
+   - 链接到 `/practice/193`、`/practice/194`、`/practice/168`、`/practice/125`
+
+3. 样式：
+   - 文件：`app/globals.css`
+   - 新增首页专题入口样式和目标页相关实践卡片样式
+   - 移动端相关实践网格降为单列
+
+## 下一次复测命令
+
+```bash
+node manage/gsc-query.js "sc-domain:skill-cn.com"
+```
+
+```bash
+rg -n 'home_seo_guide_click|seo-related-card|openclaw-wsl2-codex-tool-calls' \
+  components/home/HomeRetentionBanner.tsx \
+  app/seo/openclaw-wsl2-codex-tool-calls/page.tsx \
+  app/globals.css
+```


### PR DESCRIPTION
## Summary
- add a visible homepage entry for the OpenClaw WSL2 / Codex tool calls SEO guide
- add related practice links on the target SEO page to form a stronger topic cluster
- add a 5-action optimization schedule for follow-up SEO work

## Verification
- npm run build
- rg -n 'SEO_GUIDE_LINK|home_seo_guide_click|pc-retention-seo-link|relatedPracticeLinks|seo-related-card|OpenClaw SEO Optimization Plan' components/home/HomeRetentionBanner.tsx app/seo/openclaw-wsl2-codex-tool-calls/page.tsx app/globals.css manage/seo-openclaw-optimization-plan-2026-06-25.md
